### PR TITLE
fixing hashtag associotion secondary ref

### DIFF
--- a/tweetsql/model.py
+++ b/tweetsql/model.py
@@ -19,8 +19,8 @@ class Hashtag(Base):
     __tablename__ = 'hashtag'
     id = Column(Integer, primary_key=True)
     hashtag = Column(String(200), nullable=False)
-    users = relationship('User', backref='hashtags', secondary='hashtag_user')
-    tweets = relationship('Tweet', backref='hashtags', secondary='hashtag_tweet')
+    users = relationship('User', backref='hashtags', secondary=hashtag_user)
+    tweets = relationship('Tweet', backref='hashtags', secondary=hashtag_tweet)
 
     def __repr(self):
         return '<Hashtag {}>'.format(self.hashtag)


### PR DESCRIPTION
the secondary table reference in the association table relationship had quotes around the table name
